### PR TITLE
Derive Eq with PartialEq to satisfy clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod tee;
 #[cfg(feature = "tee-sev")]
 pub use tee::sev::{SevChallenge, SevRequest};
 
-#[derive(Serialize, Clone, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Tee {
     Sev,


### PR DESCRIPTION
Starting 1.63.0, clippy suggests to derive Eq where it's possible and
PartialEq is derived. Do that to fix its warnings.

Signed-off-by: Sergio Lopez <slp@redhat.com>