### PR TITLE
lib: Add struct Register

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,3 @@ sev = { version = "0.3.0", features = ["openssl"], optional = true }
 codicon = "3.0.0"
 procfs = "0.10.1"
 reqwest = "0.9.15"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [features]
 tee-sev = [ "sev" ]
+tee-snp = [ "sev" ]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/tee/mod.rs
+++ b/src/tee/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(feature = "tee-sev")]
 pub mod sev;
+
+#[cfg(feature = "tee-snp")]
+pub mod snp;

--- a/src/tee/snp.rs
+++ b/src/tee/snp.rs
@@ -1,0 +1,4 @@
+#[derive(Serialize, Deserialize)]
+pub struct SnpRequest {
+    pub workload_id: String,
+}


### PR DESCRIPTION
The Register struct will be used when registering a workload (like in register_workload() in reference-kbs). It contains no TEE-specific data; only the ID, measurement, TEE-config info, and passphrase to unlock the disk.

Signed-off-by: Tyler Fanelli <tfanelli@redhat.com>