### PR TITLE
Prepare to release v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kbs-types"
 description = "Rust (de)serializable types for KBS"
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 homepage = "https://github.com/virtee/kbs-types"


### PR DESCRIPTION
Adjust internal version to reflect the version of the KBS protocol implemented in this crate (v0.1.0).

Signed-off-by: Sergio Lopez <slp@redhat.com>