### PR TITLE
Derive Clone for TeePubKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub struct Challenge {
     pub extra_params: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct TeePubKey {
     pub kty: String,
     pub alg: String,


### PR DESCRIPTION
The TEE generated public key is something KBSes will most likely want to keep a copy of.

Signed-off-by: Samuel Ortiz <sameo@rivosinc.com>