### PR TITLE
Add launch registration and SNP module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tee-snp = [ "sev" ]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sev = { version = "0.3.0", features = ["openssl"], optional = true }
+sev = { version = "1.0.1", features = ["openssl"], optional = true }
 
 [dev-dependencies]
 codicon = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [features]
 tee-sev = [ "sev" ]
+tee-snp = [ "sev" ]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ mod tee;
 #[cfg(feature = "tee-sev")]
 pub use tee::sev::{SevChallenge, SevRequest};
 
+#[cfg(feature = "tee-snp")]
+pub use tee::snp::SnpRequest;
+
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Tee {

--- a/src/tee/mod.rs
+++ b/src/tee/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(feature = "tee-sev")]
 pub mod sev;
+
+#[cfg(feature = "tee-snp")]
+pub mod snp;

--- a/src/tee/sev.rs
+++ b/src/tee/sev.rs
@@ -26,7 +26,7 @@ mod tests {
     use procfs::CpuInfo;
     use sev::certs;
     use sev::certs::Verifiable;
-    use sev::firmware::Firmware;
+    use sev::firmware::host::Firmware;
     use sev::launch::sev::Policy;
     use sev::session::Session;
 

--- a/src/tee/snp.rs
+++ b/src/tee/snp.rs
@@ -4,3 +4,9 @@ use serde::{Deserialize, Serialize};
 pub struct SnpRequest {
     pub workload_id: String,
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct SnpAttestation {
+    pub report: String,
+    pub cert_chain: String,
+}

--- a/src/tee/snp.rs
+++ b/src/tee/snp.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct SnpRequest {
+    pub workload_id: String,
+}


### PR DESCRIPTION
This PR does a few things

- Adds a struct Register for registering launch measurements (not specifically a part of the KBS protocol, but still a valid step in most processes)
- Adds a module related to types for AMD SEV-SNP attestation.