### PR TITLE
SNP: Edit TeePubKey and add generation to SnpRequest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,11 @@ pub struct Challenge {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct TeePubKey {
-    pub kty: String,
     pub alg: String,
-    pub k: String,
+    #[serde(rename = "k-mod")]
+    pub k_mod: String,
+    #[serde(rename = "k-exp")]
+    pub k_exp: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -125,18 +127,18 @@ mod tests {
         let data = r#"
         {
             "tee-pubkey": {
-                "kty": "fakekeytype",
                 "alg": "fakealgorithm",
-                "k": "fakepubkey"
+                "k-mod": "fakemodulus",
+                "k-exp": "fakeexponent"
             },
             "tee-evidence": "fakeevidence"
         }"#;
 
         let attestation: Attestation = serde_json::from_str(data).unwrap();
 
-        assert_eq!(attestation.tee_pubkey.kty, "fakekeytype");
         assert_eq!(attestation.tee_pubkey.alg, "fakealgorithm");
-        assert_eq!(attestation.tee_pubkey.k, "fakepubkey");
+        assert_eq!(attestation.tee_pubkey.k_mod, "fakemodulus");
+        assert_eq!(attestation.tee_pubkey.k_exp, "fakeexponent");
         assert_eq!(attestation.tee_evidence, "fakeevidence");
     }
 

--- a/src/tee/snp.rs
+++ b/src/tee/snp.rs
@@ -9,4 +9,5 @@ pub struct SnpRequest {
 pub struct SnpAttestation {
     pub report: String,
     pub cert_chain: String,
+    pub gen: String,
 }


### PR DESCRIPTION
The current `mod` parameter of the `TeePubKey` struct both is a short form for the modulus of an RSA public key, but is also confused by Rust as the `mod` keyword. I propose removing the `r#mod` code and would prefer to just call the parameter `k_mod` (in JSON, `k-mod`). This isn't a big issue and can easily be dropped if others disagree.

For adding the generation parameter to `SnpAttestation`: currently in `reference-kbs`, our ASK and ARK keys are distinguished by their generation (i.e. Milan ASK and ARKs differ from Genoa ASK and ARKs). Thus, to know which key pair to retrieve, we need to know which generation we are currently attesting for.