### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kbs-types"
 description = "Rust (de)serializable types for KBS"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 homepage = "https://github.com/virtee/kbs-types"


### PR DESCRIPTION
As #15 introduced API-breaking changes, bump minor version. We're now at 0.2.0.