### PR TITLE
Add azure sev-snp vtpm-based TEE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kbs-types"
 description = "Rust (de)serializable types for KBS"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 homepage = "https://github.com/virtee/kbs-types"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use tee::snp::{SnpAttestation, SnpRequest};
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Tee {
+    AzSnpVtpm,
     Sev,
     Sgx,
     Snp,


### PR DESCRIPTION
This is an azure specific TEE entry. Azure CVMs today provide a discrete method to retrieve Attestation Evidence in an SEV-SNP guest via vTPM. Details can be found [here](https://github.com/Azure/confidential-computing-cvm-guest-attestation/blob/main/cvm-guest-attestation.md#linux).

We're adding this entry because kbs-types is consumed by CoCo's Attestation Agent/Service, for which we are creating attester and verifier cc_kbc modules.