### PR TITLE
CODEOWNERS: Shamelessly adding myself

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @crobinso @slp @tylerfanelli
+* @crobinso @slp @tylerfanelli @sameo


### PR DESCRIPTION
As downstream consumers of the kbs-types crate, the Confidential Containers kbs, attestation-service and attestation-agent crates should be notified of any new release, breaking changes, etc.

As a maintainer for the CoCo project, adding myself to the CODEOWNERS file will facilitate that.