### PR TITLE
kbs-types: Add a key type field for publick keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tee-snp = [ "sev" ]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sev = { version = "1.1.0", features = ["openssl"], optional = true }
+sev = { version = "1.2.0", features = ["openssl"], optional = true }
 
 [dev-dependencies]
 codicon = "3.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub struct Challenge {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct TeePubKey {
+    pub kty: String,
     pub alg: String,
     #[serde(rename = "n")]
     pub k_mod: String,
@@ -130,6 +131,7 @@ mod tests {
         let data = r#"
         {
             "tee-pubkey": {
+                "kty": "fakekeytype",
                 "alg": "fakealgorithm",
                 "n": "fakemodulus",
                 "e": "fakeexponent"
@@ -139,6 +141,7 @@ mod tests {
 
         let attestation: Attestation = serde_json::from_str(data).unwrap();
 
+        assert_eq!(attestation.tee_pubkey.kty, "fakekeytype");
         assert_eq!(attestation.tee_pubkey.alg, "fakealgorithm");
         assert_eq!(attestation.tee_pubkey.k_mod, "fakemodulus");
         assert_eq!(attestation.tee_pubkey.k_exp, "fakeexponent");


### PR DESCRIPTION
Both EC and RSA JWK-formatted public keys must specify a key type through the `kty` type.
See https://www.rfc-editor.org/rfc/rfc7518.html#section-6 for further reference.