### PR TITLE
Fix `tee-snp` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [features]
 tee-sev = [ "sev" ]
-tee-snp = [ "sev" ]
+tee-snp = [ ]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
The `tee-snp` feature enables the `sev` dependency but it doesn't actually use anything from that crate, so let's remove it to minimize dependencies.