### PR TITLE
Add new features to use this crate without the standard library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,15 @@ homepage = "https://github.com/virtee/kbs-types"
 license = "Apache-2.0"
 
 [features]
+default = [ "std" ]
+alloc = [ "serde/alloc", "serde_json/alloc" ]
+std = [ "serde/std", "serde_json/std" ]
 tee-sev = [ "sev" ]
 tee-snp = [ ]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0", default-features = false }
 sev = { version = "1.2.0", features = ["openssl"], optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,15 @@
+// Support using this crate without the standard library
+#![cfg_attr(not(feature = "std"), no_std)]
+// As long as there is a memory allocator, we can still use this crate
+// without the rest of the standard library by using the `alloc` crate
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::string::String;
+#[cfg(feature = "std")]
+use std::string::String;
+
 use serde::{Deserialize, Serialize};
 
 mod tee;

--- a/src/tee/sev.rs
+++ b/src/tee/sev.rs
@@ -3,6 +3,8 @@ use sev::certs::sev::Chain;
 use sev::launch::sev::Start;
 use sev::Build;
 
+use crate::String;
+
 #[derive(Serialize, Deserialize)]
 pub struct SevRequest {
     pub build: Build,

--- a/src/tee/snp.rs
+++ b/src/tee/snp.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::String;
+
 #[derive(Serialize, Deserialize)]
 pub struct SnpRequest {
     pub workload_id: String,


### PR DESCRIPTION
It can be useful to use this crate in bare-metal code where `std` is not available (e.g. SVSM).

So let's provide 2 new features (`std` and `alloc`) to support this use case. `std` is enabled by default.

As long as there is a memory allocator, we can still use this crate without the rest of the standard library by enabling the `alloc` feature:

  `kbs-types = { version = "...", default-features = false,
                 features = ["alloc"] }`

The patch is based on what serde does to handle the same use case.