### PR TITLE
Add AzTdxVtpm tee type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use tee::snp::{SnpAttestation, SnpRequest};
 #[serde(rename_all = "lowercase")]
 pub enum Tee {
     AzSnpVtpm,
+    AzTdxVtpm,
     Sev,
     Sgx,
     Snp,


### PR DESCRIPTION
This is a new TEE type for Intel TDX VMs on Azure that rely on a vTPM for attestation