### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Rust (de)serializable types for KBS"
 version = "0.6.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
-homepage = "https://github.com/virtee/kbs-types"
+repository = "https://github.com/virtee/kbs-types"
 license = "Apache-2.0"
 
 [features]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).