### PR TITLE
Update to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kbs-types"
 description = "Rust (de)serializable types for KBS"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 repository = "https://github.com/virtee/kbs-types"


### PR DESCRIPTION
Although not reflected in the Cargo.toml file, version 0.8.0 of this crate was already released.