### PR TITLE
Apply RFC7516 Standard to Response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tee-sev = [ "sev" ]
 tee-snp = [ "sev" ]
 
 [dependencies]
+base64 = "0.22.1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 sev = { version = "3.2.0", features = ["openssl"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 [features]
 default = [ "std" ]
 alloc = [ "serde/alloc", "serde_json/alloc" ]
-std = [ "serde/std", "serde_json/std" ]
+std = ["serde/std", "serde_json/std", "thiserror/std"]
 tee-sev = [ "sev" ]
 tee-snp = [ "sev" ]
 
@@ -19,6 +19,7 @@ base64 = "0.22.1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 sev = { version = "3.2.0", features = ["openssl"], optional = true }
+thiserror = { version = "2.0.3", default-features = false }
 
 [dev-dependencies]
 codicon = "3.0.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+pub type Result<T> = core::result::Result<T, KbsTypesError>;
+
+#[derive(Error, Debug)]
+pub enum KbsTypesError {
+    #[error("Serialize/Deserialize error")]
+    Serde,
+}


### PR DESCRIPTION
This patch is a fix up to previous commits to update the Response struct to follow RFC7516.

The work included in the commit
1. Make both serialization and deserialization of `ProtectedHeader` use base64-url-nopadding encoding. This means that the whole ProtectedHeader will be serialized into a base64 string, rather than a struct.
2. Make `encrypted_key`, `aad`, `iv`, `ciphertext`, `tag` to base64-url-nopadding encoded string when serializing.
3. Automatical deseralization logic when parsing Response from a flattened JSON JWE Serialization.
4. Add `generate_aad()` function to `ProtectedHeader`

Close #47 