### PR TITLE
plugins: Add {de}serializable type for ID-KEY ECDH exchange

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,14 @@ license = "Apache-2.0"
 
 [features]
 default = [ "std" ]
-alloc = ["base64/alloc",  "serde/alloc", "serde_json/alloc" ]
-std = ["base64/std", "serde/std", "serde_json/std", "thiserror/std"]
+alloc = ["base64/alloc", "p384/alloc", "serde/alloc", "serde_json/alloc" ]
+std = ["base64/std", "p384/std", "serde/std", "serde_json/std", "thiserror/std"]
 tee-sev = [ "sev" ]
 tee-snp = [ "sev" ]
 
 [dependencies]
 base64 = { version = "0.22.1", default-features = false }
+p384 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdh"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 sev = { version = "5.0.0", features = ["openssl"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate alloc;
 
 mod error;
+pub mod plugins;
 pub use error::{KbsTypesError, Result};
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
@@ -13,7 +14,7 @@ use alloc::{string::String, vec::Vec};
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
 use serde_json::{Map, Value};
 #[cfg(all(feature = "std", not(feature = "alloc")))]
-use std::string::String;
+use std::{string::String, vec::Vec};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod resource;

--- a/src/plugins/resource/id_key.rs
+++ b/src/plugins/resource/id_key.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::super::{deserialize_base64, serialize_base64, String, Vec};
+use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
+use p384::PublicKey;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub struct IdKeyEcdh {
+    #[serde(
+        serialize_with = "serialize_ec_public_key_sec1_base64",
+        deserialize_with = "deserialize_ec_public_key_sec1_base64"
+    )]
+    pub public_key: PublicKey,
+    #[serde(
+        serialize_with = "serialize_base64",
+        deserialize_with = "deserialize_base64"
+    )]
+    pub iv: Vec<u8>,
+}
+
+fn serialize_ec_public_key_sec1_base64<S>(
+    sub: &PublicKey,
+    serializer: S,
+) -> core::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let encoded = BASE64_URL_SAFE_NO_PAD.encode(sub.to_sec1_bytes());
+    serializer.serialize_str(&encoded)
+}
+
+fn deserialize_ec_public_key_sec1_base64<'de, D>(
+    deserializer: D,
+) -> core::result::Result<PublicKey, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let encoded = String::deserialize(deserializer)?;
+    let sec1 = BASE64_URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(serde::de::Error::custom)?;
+    let public_key = PublicKey::from_sec1_bytes(&sec1).map_err(serde::de::Error::custom)?;
+
+    Ok(public_key)
+}

--- a/src/plugins/resource/mod.rs
+++ b/src/plugins/resource/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod id_key;


### PR DESCRIPTION
To prevent replay attacks, the ID-KEY resource backend requires an ECDH public key exchange, as well as a nonce for the generated AES-GCM key that is used to wrap the encrypted key. Add a type for easy {de}serialization of this data.