### PR TITLE
Support guests with confidential devices 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub enum Tee {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Request {
     pub version: String,
-    pub tee: Tee,
+    pub tees: Vec<Tee>,
     #[serde(rename = "extra-params")]
     pub extra_params: Value,
 }
@@ -247,14 +247,14 @@ mod tests {
         let data = r#"
         {
             "version": "0.0.0",
-            "tee": "sev",
+            "tees": ["sev"],
             "extra-params": ""
         }"#;
 
         let request: Request = serde_json::from_str(data).unwrap();
 
         assert_eq!(request.version, "0.0.0");
-        assert_eq!(request.tee, Tee::Sev);
+        assert_eq!(request.tees, vec![Tee::Sev]);
         assert_eq!(request.extra_params, "");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use tee::sev::{SevChallenge, SevRequest};
 #[cfg(feature = "tee-snp")]
 pub use tee::snp::{Error as SnpDecodeError, SnpAttestation};
 
-#[derive(Serialize, Clone, Copy, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Clone, Copy, Deserialize, Debug, Eq, Hash, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Tee {
     AzSnpVtpm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,10 @@ pub enum Tee {
     // IBM Z Secure Execution
     Se,
 
-    // This value is only used for testing an attestation server, and should not
+    // These values are only used for testing an attestation server, and should not
     // be used in an actual attestation scenario.
     Sample,
+    SampleDevice,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
See https://github.com/confidential-containers/guest-components/pull/957
and https://github.com/confidential-containers/trustee/pull/752

Some guests might have confidential devices attached to them. The KBS protocol should be able to express this.

Two things to note about this: 

1) This approach is non-hierarchical. You might expect the protocol to identify one primary CPU TEE and additional devices, but this PR assumes that devices, including the CPU, are non-hierarchical and independent. This is a safe assumption if devices are attested when they are first added to the TCB (i.e. by a TSM or a kernel module). This model simplifies implementation, is more scalable, and handles edge cases nicely.

2) The KBS protocol doesn't know about the structure of the evidence. The biggest changes for multi-device happen in the evidence itself, but the evidence is opaque to kbs-types. I continue this approach. There might be some benefits to introducing more explicit structures for multi-device evidence, but this would make kbs-types more tied to the Trustee implementation, which we might not want. Currently I am proposing the most minimal set of changes to this repo.