### PR TITLE
snp: Adding Turing generation support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tee-snp = [ "sev" ]
 base64 = { version = "0.22.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
-sev = { version = "5.0.0", features = ["openssl"], optional = true }
+sev = { version = "6.0.0", features = ["openssl"], optional = true }
 thiserror = { version = "2.0.3", default-features = false }
 
 [dev-dependencies]

--- a/src/tee/snp.rs
+++ b/src/tee/snp.rs
@@ -14,7 +14,7 @@ pub enum Error {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SnpAttestation {
     pub report: String,
-    pub gen: String,
+    pub r#gen: String,
 }
 
 impl TryInto<(AttestationReport, Generation)> for SnpAttestation {
@@ -22,14 +22,15 @@ impl TryInto<(AttestationReport, Generation)> for SnpAttestation {
 
     fn try_into(self) -> Result<(AttestationReport, Generation), Self::Error> {
         let report: AttestationReport = from_str(&self.report).map_err(Error::ReportDecode)?;
-        let gen = match &self.gen[..] {
+        let r#gen = match &self.r#gen[..] {
             "naples" => Generation::Naples,
             "rome" => Generation::Rome,
             "milan" => Generation::Milan,
             "genoa" => Generation::Genoa,
+            "turin" => Generation::Turin,
             _ => return Err(Error::GenerationDecode),
         };
 
-        Ok((report, gen))
+        Ok((report, r#gen))
     }
 }


### PR DESCRIPTION
- Upgrading `sev` to version `6.0.0`.
- Adding "turin" string map to `Generation::Turin` from sev crate (6.0.0).
- Specifying legacy field `gen` as `r#gen` to protect against the keyword `gen` which is now reserved for generators in later versions of rust.