### PR TITLE
Support Attesting Multiple Devices (Take 2)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use tee::sev::{SevChallenge, SevRequest};
 #[cfg(feature = "tee-snp")]
 pub use tee::snp::{Error as SnpDecodeError, SnpAttestation};
 
-#[derive(Serialize, Clone, Copy, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Clone, Copy, Deserialize, Debug, Eq, Hash, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Tee {
     AzSnpVtpm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,10 @@ pub enum Tee {
     // IBM Z Secure Execution
     Se,
 
-    // This value is only used for testing an attestation server, and should not
+    // These values are only used for testing an attestation server, and should not
     // be used in an actual attestation scenario.
     Sample,
+    SampleDevice,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This supersedes #58 

(I am keeping the original branches in place in case someone is developing on top of them).

After some refinement, it turns out we don't need to change much in this crate. We just need to introduce a new Tee type (we are treating devices basically the same as CPUs) and make the enum hashable. For Trustee everything else happens at the level of the evidence, which is not defined here.