### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kbs-types"
 description = "Rust (de)serializable types for KBS"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 repository = "https://github.com/virtee/kbs-types"


### PR DESCRIPTION
Set up the stage for a new release that bumps the sev dep to 0.6.0 and includes supports for turing generation.