### PR TITLE
Add TPM tee

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,9 @@ pub enum Tee {
     /// Hygon DCU (Deep Computing Unit)
     HygonDcu,
 
+    // Trusted Platform Module
+    Tpm,
+
     // These values are only used for testing an attestation server, and should not
     // be used in an actual attestation scenario.
     Sample,


### PR DESCRIPTION
In the KBS protocol, TPMs can be used in order to generate and sign the attestation evidence.

This is required in order to add a TPM verifier in trustee, see https://github.com/confidential-containers/trustee/issues/846